### PR TITLE
ESLINT-26 change to module.exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "prettier": "@checkdigit/prettier-config",
   "main": "dist/index.js",
   "scripts": {
-    "test": "npm run build && node tests/no-card-numbers.js && npm run prettier",
+    "test": "npm run build && node dist/tests/no-card-numbers.js && npm run prettier",
     "prettier": "prettier --list-different src/**/*.ts",
     "prettier:fix": "prettier --write src/**/*.ts",
     "build": "tsc"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Rule } from 'eslint';
 import { Literal, Node, SourceLocation, TemplateElement } from 'estree';
 
-export const CARD_NUMBER_FOUND = 'CARD_NUMBER_FOUND';
-export const CARD_NUMBERS_FOUND = 'CARD_NUMBERS_FOUND';
+const CARD_NUMBER_FOUND = 'CARD_NUMBER_FOUND';
+const CARD_NUMBERS_FOUND = 'CARD_NUMBERS_FOUND';
 const cardNumberRegex = /\d{15,19}/gm;
 
 function luhnCheck(cardNumber: string) {
@@ -117,7 +117,7 @@ const rule = {
   }
 };
 
-export default {
+module.exports = {
   rules: {
     'no-card-numbers': rule
   }

--- a/src/tests/no-card-numbers.ts
+++ b/src/tests/no-card-numbers.ts
@@ -1,4 +1,7 @@
-import plugin, { CARD_NUMBER_FOUND, CARD_NUMBERS_FOUND } from '..';
+const CARD_NUMBER_FOUND = 'CARD_NUMBER_FOUND';
+const CARD_NUMBERS_FOUND = 'CARD_NUMBERS_FOUND';
+
+const plugin = require('../index.js');
 
 const { RuleTester } = require('eslint/lib/rule-tester');
 const rule = plugin.rules['no-card-numbers'];
@@ -18,7 +21,7 @@ const NOT_A_SECRET = "I'm not a secret, I think";
 
 const TEMPLATE_TEST = "const NOT_A_SECRET = `A template that isn't a secret. ${1+1} = 2`";
 
-const CONTAINS_CARD_NUMBER_IN_STRING = `
+const CONTAINS_CARD_NUMBER_IN_NUMBER = `
 const foo = 4507894813950280;
 `;
 
@@ -54,7 +57,7 @@ ruleTester.run('no-card-numbers', rule, {
   ],
   invalid: [
     {
-      code: CONTAINS_CARD_NUMBER_IN_STRING,
+      code: CONTAINS_CARD_NUMBER_IN_NUMBER,
       errors: [CARD_NUMBER_FOUND_MSG]
     },
     {


### PR DESCRIPTION
It seems that at some point very recently eslint stopped liking default exports and this was an issue. Fixes issue withe eslint-config 3.1.1